### PR TITLE
Add support for automatically reacting to approved submissions

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,5 +1,5 @@
 token: ''
-mute_role: '873033466734841926'
+mute_role: ''
 prefix: '!'
 database:
   user: 'postgres'

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,9 @@
+token: ''
+mute_role: '873033466734841926'
+prefix: '!'
+database:
+  user: 'postgres'
+  host: 'localhost'
+  database: 'postgres'
+  password: 'postgres'
+  port: 5432

--- a/pg.sql
+++ b/pg.sql
@@ -64,3 +64,5 @@ create unique index if not exists submissions_review_message_id_uindex_2
 create unique index if not exists submissions_submission_id_uindex
     on anon_muting.submissions (submission_id);
 
+alter table anon_muting.events 
+  add column if not exists publish_reactions text[] not null default '{}';

--- a/src/commands/events/addreaction.ts
+++ b/src/commands/events/addreaction.ts
@@ -1,0 +1,55 @@
+import { CommandoClient, Command, CommandoMessage } from 'discord.js-commando';
+import { GuildEmoji } from 'discord.js';
+import { pool } from '../../db/db';
+
+export = class AddReaction extends Command {
+  constructor(bot: CommandoClient) {
+    super(bot, {
+      name: 'add_reaction',
+      aliases: ['areact', 'add_react', 'addreaction', 'addreact'],
+      group: 'events',
+      memberName: 'add reaction',
+      userPermissions: ['MANAGE_CHANNELS'],
+      description: 'Add a reaction to be automatically applied to approved submissions',
+      args: [
+        {
+          key: 'name',
+          prompt: 'The name of the event',
+          type: 'string',
+        },
+        {
+          key: 'emoji',
+          prompt: 'The emote to apply to the approved submission',
+          type: 'custom-emoji|default-emoji',
+        },
+      ],
+      argsType: 'multiple',
+      guildOnly: true,
+    });
+  }
+
+  async run(msg: CommandoMessage, { name, emoji }: { name: string, emoji: string | GuildEmoji}) {
+    let action: string;
+    if (typeof emoji === 'string') {
+      action = emoji;
+    } else if (emoji instanceof GuildEmoji) {
+      if (!emoji.available) {
+        return msg.reply('This emoji is not available');
+      }
+      action = emoji.id;
+    } else {
+      return msg.reply('Emote was not in a recognised form');
+    }
+    const result = await pool.query('UPDATE anon_muting.events\
+                                      SET publish_reactions = array_append( publish_reactions, $1 )\
+                                      WHERE\
+                                        name = $2\
+                                        AND NOT $1 = ANY ( publish_reactions ) RETURNING event_id',
+      [action, name]);
+    if (result.rowCount) {
+      return msg.reply('Added this emote to the reaction list');
+    } else {
+      return msg.reply('Either the selected event does not exist, or this emote is already a part of it');
+    }
+  }
+}

--- a/src/commands/events/delreaction.ts
+++ b/src/commands/events/delreaction.ts
@@ -1,0 +1,55 @@
+import { CommandoClient, Command, CommandoMessage } from 'discord.js-commando';
+import { GuildEmoji } from 'discord.js';
+import { pool } from '../../db/db';
+
+export = class DelReaction extends Command {
+  constructor(bot: CommandoClient) {
+    super(bot, {
+      name: 'del_reaction',
+      aliases: ['dreact', 'del_react', 'delreaction', 'delreact'],
+      group: 'events',
+      memberName: 'delete reaction',
+      userPermissions: ['MANAGE_CHANNELS'],
+      description: 'Remove an emote from being automatically added as a reaction to approved submissions',
+      args: [
+        {
+          key: 'name',
+          prompt: 'The name of the event',
+          type: 'string',
+        },
+        {
+          key: 'emoji',
+          prompt: 'The emote to apply to no longer apply to the approved submission',
+          type: 'custom-emoji|default-emoji',
+        },
+      ],
+      argsType: 'multiple',
+      guildOnly: true,
+    });
+  }
+
+  async run(msg: CommandoMessage, { name, emoji }: { name: string, emoji: string | GuildEmoji}) {
+    let action: string;
+    if (typeof emoji === 'string') {
+      action = emoji;
+    } else if (emoji instanceof GuildEmoji) {
+      if (!emoji.available) {
+        return msg.reply('This emoji is not available');
+      }
+      action = emoji.id;
+    } else {
+      return msg.reply('Emote was not in a recognised form');
+    }
+    const result = await pool.query('UPDATE anon_muting.events\
+                                      SET publish_reactions = array_remove( publish_reactions, $1 )\
+                                      WHERE\
+                                        name = $2\
+                                        AND $1 = ANY ( publish_reactions ) RETURNING event_id',
+      [action, name]);
+    if (result.rowCount) {
+      return msg.reply('Removed this emote from the reaction list');
+    } else {
+      return msg.reply('Either the selected event does not exist, or this emote wasn\'t on the reaction list in the first place');
+    }
+  }
+}

--- a/src/commands/events/listevents.ts
+++ b/src/commands/events/listevents.ts
@@ -1,0 +1,75 @@
+import { CommandoClient, Command, CommandoMessage } from 'discord.js-commando';
+import { MessageEmbed } from 'discord.js';
+import { pool } from '../../db/db';
+
+export = class ListEvents extends Command {
+  constructor(bot: CommandoClient) {
+    super(bot, {
+      name: 'list_events',
+      aliases: ['lsevent', 'lsevents', 'listevents', 'listevent', 'list_event'],
+      group: 'events',
+      memberName: 'list events',
+      userPermissions: ['MANAGE_CHANNELS'],
+      description: 'List events for suggestions',
+      guildOnly: true,
+    });
+  }
+
+  async run(msg: CommandoMessage) {
+    const results = await pool.query<{
+      created_by: string;
+      submissions_channel_id: string;
+      review_channel_id: string;
+      name: string;
+      restriction: number;
+      publish_reactions: string[];
+    }>('SELECT created_by, submissions_channel_id, review_channel_id, name, restriction, publish_reactions FROM anon_muting.events WHERE active = true');
+    const rows = results.rows;
+    let lastReply: CommandoMessage | undefined;
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      const embed = new MessageEmbed();
+      embed.setTitle(row.name);
+      embed.addField("Submissions", `<#${row.submissions_channel_id}>`, true);
+      embed.addField("Review", `<#${row.review_channel_id}>`, true);
+      embed.addField("Created by", `<@${row.created_by}>`);
+      switch (row.restriction) {
+        default:
+          embed.addField("Restrictions", `Unknown (${row.restriction})`);
+          break;
+        case 0:
+          break;
+        case 1:
+          embed.addField("Restrictions", "Image only");
+          break;
+        case 2:
+          embed.addField("Restrictions", "GIF/MP4 only");
+          break;
+        case 3:
+          embed.addField("Restrictions", "Require attachment");
+          break;
+        case 4:
+          embed.addField("Restrictions", "Text only");
+          break;
+      }
+      const reactionList = row.publish_reactions;
+      if (reactionList.length !== 0) {
+        const formattedList = [];
+        for (let i = 0; i < reactionList.length; i++) {
+          const emote = reactionList[i];
+          if (emote.length > 4) {
+            formattedList.push(`<:reaction:${emote}>`);
+          } else {
+            formattedList.push(emote);
+          }
+        }
+        embed.addField("Reactions", formattedList.join(' '));
+      }
+      lastReply = await msg.replyEmbed(embed);
+    }
+    if (lastReply === void 0) {
+      return msg.reply("There are no active events");
+    }
+    return lastReply;
+  }
+}

--- a/src/handler/reactionhandler.ts
+++ b/src/handler/reactionhandler.ts
@@ -31,7 +31,7 @@ export default class ReactionHandler {
 
     private async handleSubmissionReview() {
       const submission = await pool.query(
-        'SELECT e.submissions_channel_id, submission_id, user_id FROM anon_muting.submissions \
+        'SELECT e.submissions_channel_id, submission_id, user_id, publish_reactions FROM anon_muting.submissions \
             INNER JOIN anon_muting.events e on e.event_id = submissions.event_id \
             WHERE submissions.review_message_id = $1 AND e.review_channel_id = $2', [this.reaction.message.id, this.reaction.message.channel.id],
       );
@@ -75,9 +75,15 @@ export default class ReactionHandler {
           submissionEmbed.author = {
             name: 'Submission',
           };
-          await submissionsChannel.send(submissionEmbed);
+          const createdMessage = await submissionsChannel.send(submissionEmbed);
 
           approved = true;
+
+          const neededReactions = submission.rows[0].publish_reactions;
+          for (let i = 0; i < neededReactions.length; i++) {
+            const reaction = neededReactions[i];
+            await createdMessage.react(reaction);
+          }
           break;
 
         case '👎':


### PR DESCRIPTION
This PR adds support for the bot to add reactions to approved submissions.
The reason is that https://github.com/NewCircuit/autoreact is somewhat flawed in that it will attempt to add reactions to a message that was deleted by this bot for the approval process, resulting in an error being printed to it's console.
Rather than trying to catch the error on the autoreact bot, I think it makes more sense to apply the reaction functionality directly to this bot, with the bonus of being able to configure reactions on a per-event basis rather than using the same combination of reactions in all subscribed channels which is how the autoreact bot appears to function.